### PR TITLE
FIX Evaluation of nested macros in encode macro

### DIFF
--- a/src/main/java/password/pwm/util/macro/MacroMachine.java
+++ b/src/main/java/password/pwm/util/macro/MacroMachine.java
@@ -164,12 +164,15 @@ public class MacroMachine {
 
         final Set<MacroImplementation.Scope> scopes = effectiveScopes(macroRequestInfo);
         final Map<Pattern,MacroImplementation> macroImplementations = new LinkedHashMap<>();
-        for (final MacroImplementation.Scope scope : scopes) {
-            macroImplementations.putAll(BUILTIN_MACROS.get(scope));
-        }
+        //First the User macros
         if (scopes.contains(MacroImplementation.Scope.User)) {
             macroImplementations.putAll(makeExternalImplementations(pwmApplication));
         }
+        //last the buitin macros for Encrypt/Encode to work properly
+        for (final MacroImplementation.Scope scope : scopes) {
+            macroImplementations.putAll(BUILTIN_MACROS.get(scope));
+        }
+
 
         String workingString = input;
         final String previousString = workingString;

--- a/src/main/java/password/pwm/util/macro/StandardMacros.java
+++ b/src/main/java/password/pwm/util/macro/StandardMacros.java
@@ -58,8 +58,7 @@ public abstract class StandardMacros {
     static {
         final Map<Class<? extends MacroImplementation>, MacroImplementation.Scope> defaultMacros = new LinkedHashMap<>();
 
-        // wrapper macros
-        defaultMacros.put(EncodingMacro.class, MacroImplementation.Scope.System);
+       
 
         // system macros
         defaultMacros.put(CurrentTimeMacro.class, MacroImplementation.Scope.System);
@@ -82,6 +81,9 @@ public abstract class StandardMacros {
         defaultMacros.put(UserEmailMacro.class, MacroImplementation.Scope.User);
         defaultMacros.put(UserPasswordMacro.class, MacroImplementation.Scope.User);
         defaultMacros.put(UserLdapProfileMacro.class, MacroImplementation.Scope.User);
+        
+        // wrapper macros: must be at the end to allow Macro in Macro during parsing
+        defaultMacros.put(EncodingMacro.class, MacroImplementation.Scope.System);
         STANDARD_MACROS = Collections.unmodifiableMap(defaultMacros);
     }
 


### PR DESCRIPTION
In the actual implementation of the MacroMachine the order of the MacroImplementations is relevant regarding the Encode macro. 

We must ensure that a inner macro in the value part of the Encode macro gets evaluated first/before the evaluation of the Encode macro itself. Otherwise the parameter would have been encoded, an inner macro would be replaced by an encoded value, thus won't get replaced/evaluated any more.

Non working example:  @Encode:urlPath:[[@User:Password@]]@ 

This fixes it.